### PR TITLE
'hd' hosted domain support to restrict access to specific domain

### DIFF
--- a/OpenIDConnect.class.php
+++ b/OpenIDConnect.class.php
@@ -119,6 +119,9 @@ class OpenIDConnect extends PluggableAuth {
 			if ( isset( $_REQUEST['forcelogin'] ) ) {
 				$oidc->addAuthParam( array( 'prompt' => 'login' ) );
 			}
+			if ( isset( $config['hd'] ) ) {
+				$oidc->addAuthParam( array( 'hd' => $config['hd'] ) );
+			}
 			if ( isset( $config['scope'] ) ) {
 				$scope = $config['scope'];
 				if ( is_array( $scope ) ) {


### PR DESCRIPTION
Optional hd parameter to limit sign-in to a particular Google Apps hosted domain, as per https://developers.google.com/identity/protocols/OpenIDConnect#hd-param

Signed-off-by: imreFitos imre.fitos@gmail.com
