### PR TITLE
fix: sqlite compatibility

### DIFF
--- a/sql/sqlite/AddTable.sql
+++ b/sql/sqlite/AddTable.sql
@@ -1,0 +1,6 @@
+CREATE TABLE /*_*/openid_connect (
+  oidc_user int unsigned PRIMARY KEY NOT NULL,
+  oidc_subject TINYBLOB NOT NULL,
+  oidc_issuer TINYBLOB NOT NULL
+) /*$wgDBTableOptions*/;
+CREATE INDEX /*i*/openid_connect_subject ON /*_*/openid_connect (oidc_subject(50),oidc_issuer(50));

--- a/sql/sqlite/DropColumnsFromUserTable.sql
+++ b/sql/sqlite/DropColumnsFromUserTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE /*_*/user DROP COLUMN subject, DROP COLUMN issuer;


### PR DESCRIPTION
Add a sqlite directory to alter the db when using this extension on a mediawiki installation with sqlite